### PR TITLE
perf: improve fromBase64 with u16

### DIFF
--- a/fallback/base64.js
+++ b/fallback/base64.js
@@ -126,6 +126,8 @@ export function toBase64(arr, isURL, padding) {
 
 // TODO: can this be optimized? This only affects non-Hermes barebone engines though
 const mapSize = nativeEncoder ? 128 : 65_536 // we have to store 64 KiB map or recheck everything if we can't decode to byte array
+const _AA = 0x4141 // 'AA' string in hex, the only allowed char pair to generate 12 zero bits
+const _zz = 0x7a7a // 'zz' string in hex, max allowed char pair
 
 export function fromBase64(str, isURL) {
   let inputLength = str.length
@@ -153,19 +155,58 @@ export function fromBase64(str, isURL) {
   let i = 0
 
   if (nativeEncoder) {
+    if (!helpers.fromMap16) {
+      helpers.fromMap16 = new Uint16Array(_zz + 1) // Warning: 64 KiB
+      const u8 = new Uint8Array(2)
+      const u16 = new Uint16Array(u8.buffer, u8.byteOffset, 1) // for endianess-agnostic transform
+      alphabet.forEach((c0, i0) => {
+        u8[0] = c0.charCodeAt(0) // FIXME, we should avoid calling charCodeAt in a loop
+        alphabet.forEach((c1, i1) => {
+          u8[1] = c1.charCodeAt(0)
+          helpers.fromMap16[u16[0]] = (i0 << 6) | i1
+        })
+      })
+    }
+    const m16 = helpers.fromMap16
+
     const codes = encodeAscii(str, E_CHAR)
-    for (; i < mainLength; i += 4) {
-      const c0 = codes[i]
-      const c1 = codes[i + 1]
-      const c2 = codes[i + 2]
-      const c3 = codes[i + 3]
-      const a = (m[c0] << 18) | (m[c1] << 12) | (m[c2] << 6) | m[c3]
-      if (a < 0) throw new SyntaxError(E_CHAR)
-      arr[at] = a >> 16
-      arr[at + 1] = (a >> 8) & 0xff
-      arr[at + 2] = a & 0xff
+    const mainLength16 = mainLength >> 1
+    const codes16 = new Uint16Array(codes.buffer, codes.byteOffset, mainLength16)
+
+    // Optional fast loop
+    for (const mainLength16_2 = mainLength16 - 2; i < mainLength16_2; ) {
+      const c01 = codes16[i]
+      const c23 = codes16[i + 1]
+      const c45 = codes16[i + 2]
+      const c67 = codes16[i + 3]
+      const x01 = m16[c01]
+      const x23 = m16[c23]
+      const x45 = m16[c45]
+      const x67 = m16[c67]
+      if (!x01 && c01 !== _AA || !x23 && c23 !== _AA) throw new SyntaxError(E_CHAR)
+      if (!x45 && c45 !== _AA || !x67 && c67 !== _AA) throw new SyntaxError(E_CHAR)
+      arr[at] = x01 >> 4
+      arr[at + 1] = ((x01 & 0xf) << 4) | (x23 >> 8)
+      arr[at + 2] = x23 & 0xff
+      arr[at + 3] = x45 >> 4
+      arr[at + 4] = ((x45 & 0xf) << 4) | (x67 >> 8)
+      arr[at + 5] = x67 & 0xff
+      i += 4
+      at += 6
+    }
+
+   for (; i < mainLength16; i += 2) {
+      const c01 = codes16[i]
+      const c23 = codes16[i + 1]
+      const x01 = m16[c01]
+      const x23 = m16[c23]
+      if (!x01 && c01 !== _AA || !x23 && c23 !== _AA) throw new SyntaxError(E_CHAR)
+      arr[at] = x01 >> 4
+      arr[at + 1] = ((x01 & 0xf) << 4) | (x23 >> 8)
+      arr[at + 2] = x23 & 0xff
       at += 3
     }
+    i *= 2
   } else {
     for (; i < mainLength; i += 4) {
       const c0 = str.charCodeAt(i)


### PR DESCRIPTION
Considering this

On the downside, this consumes 64 KiB cache (and +64 KiB for base64url)

On the upside, this improves fallback perf from `5807` to `9576` on Hermes, beating `atob()` codepath used now (with `7308`)
Also significantly improves browser fallbacks (but old browsers are not important)

Likely I'll abandon this due to 128 KiB cache being too large