### PR TITLE
perf: 2.5x smaller utf8.js in browsers

### DIFF
--- a/fallback/utf8.auto.browser.js
+++ b/fallback/utf8.auto.browser.js
@@ -1,0 +1,2 @@
+export const decodeFast = null
+export const encode = null

--- a/fallback/utf8.auto.js
+++ b/fallback/utf8.auto.js
@@ -1,0 +1,1 @@
+export { decodeFast, encode } from './utf8.js'

--- a/fallback/utf8.auto.native.js
+++ b/fallback/utf8.auto.native.js
@@ -1,0 +1,1 @@
+export { decodeFast, encode } from './utf8.js'

--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
     "/fallback/single-byte.js",
     "/fallback/utf16.js",
     "/fallback/utf8.js",
+    "/fallback/utf8.auto.js",
+    "/fallback/utf8.auto.browser.js",
+    "/fallback/utf8.auto.native.js",
     "/array.js",
     "/array.d.ts",
     "/assert.js",
@@ -216,8 +219,12 @@
       "default": "./wif.js"
     }
   },
+  "browser": {
+    "./fallback/utf8.auto.js": "./fallback/utf8.auto.browser.js"
+  },
   "react-native": {
-    "./encoding-browser.js": "./encoding-browser.native.js"
+    "./encoding-browser.js": "./encoding-browser.native.js",
+    "./fallback/utf8.auto.js": "./fallback/utf8.auto.native.js"
   },
   "peerDependencies": {
     "@noble/hashes": "^1.8.0 || ^2.0.0"

--- a/tests/utf8.hermes.test.cjs
+++ b/tests/utf8.hermes.test.cjs
@@ -1,4 +1,4 @@
-delete globalThis.TextDecoder
+if (!process.env.EXODUS_TEST_IS_BROWSER) delete globalThis.TextDecoder
 delete String.prototype.isWellFormed
 delete String.prototype.toWellFormed
 

--- a/tests/utf8.noenc.test.cjs
+++ b/tests/utf8.noenc.test.cjs
@@ -1,3 +1,7 @@
-delete globalThis.TextEncoder
-delete globalThis.TextDecoder
-require('./utf8.lib.test.js')
+if (process.env.EXODUS_TEST_IS_BROWSER) {
+  require('node:test').test.skip('Under browsers, TextEncoder / TextDecoder is required')
+} else {
+  delete globalThis.TextEncoder
+  delete globalThis.TextDecoder
+  require('./utf8.lib.test.js')
+}

--- a/tests/wpt/fallback.test.cjs
+++ b/tests/wpt/fallback.test.cjs
@@ -1,6 +1,7 @@
 // Drop available native implementations so fallbacks will be used
-// The only exception is *.node.js impls, but tests in other contexts cover that
-if (!globalThis.Buffer || globalThis.Buffer.TYPED_ARRAY_SUPPORT) {
+// The exceptions for that are *.node.js impls and browser bundles, but tests in other contexts cover that
+const isNode = globalThis.Buffer && !globalThis.Buffer.TYPED_ARRAY_SUPPORT
+if (!process.env.EXODUS_TEST_IS_BROWSER && !isNode) {
   delete globalThis.TextEncoder
   delete globalThis.TextDecoder
 }

--- a/utf8.js
+++ b/utf8.js
@@ -1,6 +1,6 @@
 import { typedView } from './array.js'
 import { nativeDecoder, nativeEncoder, E_STRING, E_STRICT_UNICODE } from './fallback/_utils.js'
-import * as js from './fallback/utf8.js'
+import * as js from './fallback/utf8.auto.js'
 
 const { TextDecoder } = globalThis
 // ignoreBOM: true means that BOM will be left as-is, i.e. will be present in the output
@@ -29,7 +29,7 @@ function deLoose(str, loose, res) {
     start = pos + 1
     if (res[pos + 1] === 0xbf && res[pos + 2] === 0xbd) {
       // Found a replacement char in output, need to recheck if we encoded the input correctly
-      if (!nativeDecoder && str.length < 1e7) {
+      if (js.decodeFast && !nativeDecoder && str.length < 1e7) {
         // This is ~2x faster than decode in Hermes
         try {
           if (encodeURI(str) !== null) return res // guard against optimizing out


### PR DESCRIPTION
We trust browsers to always detect their TextDecoder / TextEncoder implementation as native, so no additional fallback is needed there

CI on browsers covers this