### PR TITLE
fix: guard utf16 native writes

### DIFF
--- a/tests/utf16.test.js
+++ b/tests/utf16.test.js
@@ -168,6 +168,22 @@ describe('utf16fromString', () => {
       }
     }
   })
+
+  if (Buffer?.prototype?.ucs2Write) {
+    test('native encode throws if ucs2Write writes fewer bytes than expected', (t) => {
+      const { ucs2Write } = Buffer.prototype
+      Buffer.prototype.ucs2Write = function partialUcs2Write(...args) {
+        ucs2Write.apply(this, args)
+        return this.byteLength - 2
+      }
+
+      try {
+        t.assert.throws(() => utf16.utf16fromString('abc'), /Failed to write all bytes/)
+      } finally {
+        Buffer.prototype.ucs2Write = ucs2Write
+      }
+    })
+  }
 })
 
 describe('random data', () => {

--- a/utf16.node.js
+++ b/utf16.node.js
@@ -22,7 +22,8 @@ function encode(str, loose = false, format = 'uint16') {
   }
 
   const ble = Buffer.allocUnsafeSlow(str.length * 2) // non-pooled
-  ble.ucs2Write(str)
+  const written = ble.ucs2Write(str)
+  if (written !== ble.byteLength) throw new Error('Failed to write all bytes') // safeguard just in case
 
   if (format === 'uint8-le') return to8(ble)
   if (format === 'uint8-be') return to8(ble.swap16())


### PR DESCRIPTION
## Summary
- Verify `Buffer#ucs2Write` fills the expected UTF-16 byte length before returning the native encoded buffer.
- Add a regression test that simulates a partial native write and asserts the guard fails closed.

## Test plan
- `pnpm exec exodus-test tests/utf16.test.js`
- `pnpm exec eslint utf16.node.js tests/utf16.test.js`