### PR TITLE
chore: lint against BigInt literals

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,6 +13,15 @@ module.exports = {
         ],
         // Subpath exports support is missing: https://github.com/import-js/eslint-plugin-import/issues/1810
         '@exodus/import/no-unresolved': [2, { ignore: ['@exodus/bytes/\\w+'] }],
+        // Hermes (and some other targets we ship to) does not support BigInt literal syntax.
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'Literal[bigint]',
+            message:
+              'BigInt literals (e.g. 1n) are not supported by all targets we ship to (e.g. Hermes); use BigInt(1) instead.',
+          },
+        ],
         'one-var': 'off',
         'unicorn/no-for-loop': 'off',
         'unicorn/no-new-array': 'off',
@@ -26,6 +35,13 @@ module.exports = {
       files: ['*.{test,bench}.?([cm])js'],
       rules: {
         'unicorn/no-useless-spread': 'off', // test vectors grouping
+      },
+    },
+    {
+      // Tests and benchmarks are not shipped, so BigInt literals are fine in fixtures.
+      files: ['**/{tests,benchmarks}/**/*.?([cm])js'],
+      rules: {
+        'no-restricted-syntax': 'off',
       },
     },
   ],

--- a/base58.js
+++ b/base58.js
@@ -162,7 +162,7 @@ function fromBase58core(str, alphabet, codes, format = 'uint8') {
 
     while (x) {
       let y = Number(x & _0xffffffffn)
-      x >>= 32n
+      x >>= _32n
       res[--at] = y & 0xff
       y >>>= 8
       if (!x && !y) break


### PR DESCRIPTION
depends on #72 

## Summary
- Adds `no-restricted-syntax: Literal[bigint]` to `.eslintrc.cjs` so new BigInt literals
(e.g. `1n`) cannot land in shipped source.
- Exempts `tests/**` and `benchmarks/**`, which aren't shipped and use literal fixtures freely.

## Why
Some runtimes we ship to (notably Hermes) don't parse BigInt literal syntax even though
they support `BigInt(n)`. The exodus-mobile patchset already rewrites such literals
(https://github.com/ExodusMovement/exodus-mobile/blob/main/src/patches-prod/exodus-bytes-
no-bigint-literal.diff). This rule prevents new ones from sneaking in.

## Notes
- Based on https://github.com/ExodusOSS/bytes/pull/72 — that PR removes the last shipped
literal (`32n` in base58.js); without it CI on this PR would be red.

## Test plan
- [x] `pnpm run lint` passes locally
- [ ] CI green
- [x] Sanity: temporarily reintroduce a `1n` in `base58.js` → lint errors with the configured message